### PR TITLE
feat: scheduled DNS sync container on lunarBeacon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 etc/porkbun.env
+etc/porkbun_secrets.env
+.env
 *.key
 certificates
 accounts

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,4 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+-include .env
+
+BATCH_HOST ?= BatchNode
+DEPLOY_PATH ?= /data/infrastructure/dns_management
+
+.PHONY: build deploy
+
+build:
+	@echo "Building dns-sync image..."
+	podman build -t localhost/dns-sync:latest -f Containerfile .
+
+deploy:
+	@echo "Deploying dns-sync to $(BATCH_HOST):$(DEPLOY_PATH)..."
+	ssh $(BATCH_HOST) 'test -d $(DEPLOY_PATH) || git clone --recurse-submodules git@github.com:NickJLange/external_dns_management.git $(DEPLOY_PATH)'
+	ssh $(BATCH_HOST) 'cd $(DEPLOY_PATH) && podman build -t localhost/dns-sync:latest -f Containerfile .'
+	ssh $(BATCH_HOST) 'mkdir -p ~/.config/containers/systemd && cp $(DEPLOY_PATH)/systemd/dns-sync.container $(DEPLOY_PATH)/systemd/dns-sync.timer ~/.config/containers/systemd/'
+	ssh $(BATCH_HOST) 'systemctl --user daemon-reload && systemctl --user enable --now dns-sync.timer && loginctl enable-linger $$(whoami)'
+	@echo "Deploy complete. etc/porkbun_secrets.env and gh auth login are one-time manual steps."

--- a/monitoring/datadog-monitor.yaml
+++ b/monitoring/datadog-monitor.yaml
@@ -1,0 +1,35 @@
+monitor:
+  name: "DNS Sync (BatchNode) - Failed or Missed"
+  type: service check
+  query: '"dns.sync.status".over("host:BatchNode").by("host").last(1).count_by_status()'
+  message: |
+    {{#is_alert}}
+    🚨 Porkbun DNS sync failed on BatchNode.
+
+    **Troubleshooting:**
+    1. `journalctl --user -u dns-sync.service -n 100`
+    2. `systemctl --user status dns-sync.timer`
+    3. Check for a git pull failure (branch protection/auth) vs a Porkbun API error
+
+    @pagerduty-dns-sync @slack-homelab-alerts
+    {{/is_alert}}
+    {{#is_recovery}}
+    ✅ DNS sync has recovered on BatchNode.
+    {{/is_recovery}}
+  options:
+    thresholds:
+      critical: 1
+      ok: 1
+    notify_no_data: true
+    no_data_timeframe: 1500
+    renotify_interval: 240
+  tags:
+    - service:dns-sync
+    - env:production
+    - team:homelab
+  priority: 2
+
+# "BatchNode" is the default h:/host: identity sent by report_service_check()
+# (scripts/manage_porkbun.py). If the real deployment sets DD_HOSTNAME in its
+# .env (e.g. to the actual host's name), update the "over(...)" query and the
+# monitor name/message above to match.

--- a/scripts/manage_porkbun.py
+++ b/scripts/manage_porkbun.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import shlex
 import subprocess
+import socket
 from dataclasses import dataclass, field
 from datetime import date
 from pathlib import Path
@@ -643,6 +644,41 @@ def process_domain(domain, dry_run=False):
         create_record(domain, add_key, record, dry_run=dry_run)
 
 
+def report_service_check(status: int) -> None:
+    """Send a DogStatsD service check to the local Datadog agent on the batch host.
+
+    status: 0=OK, 2=CRITICAL. Best-effort; never raises, since a monitoring
+    hiccup must never fail the DNS sync itself.
+    """
+    host = os.environ.get("DD_AGENT_HOST", "172.17.0.1")
+    hostname = os.environ.get("DD_HOSTNAME", "BatchNode")
+    msg = f"_sc|dns.sync.status|{status}|h:{hostname}"
+    try:
+        port = int(os.environ.get("DD_AGENT_PORT", "8125"))
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.sendto(msg.encode(), (host, port))
+    except (OSError, ValueError):
+        pass
+
+
+def sync_domains(domains_to_process: list, dry_run: bool = False, verbose: bool = False) -> bool:
+    """Run process_domain for each domain in domains_to_process.
+
+    Returns True only if every domain synced without raising.
+    """
+    all_succeeded = True
+    for domain_name in domains_to_process:
+        try:
+            process_domain(domain_name, dry_run=dry_run)
+        except Exception as e:
+            all_succeeded = False
+            logger.error(f"Error processing domain {domain_name}: {e}")
+            if verbose:
+                import traceback
+                traceback.print_exc()
+    return all_succeeded
+
+
 @click.command()
 @click.option(
     "--dry-run", is_flag=True, help="Show what would be done without making changes"
@@ -703,6 +739,8 @@ def main(dry_run, verbose, domain, catch_up):
     else:
         domains_to_process = app_config["domains"]
 
+    sync_ok = True
+
     if catch_up:
         # --- catch-up mode: diff only, no sync ---
         total_records = 0
@@ -718,6 +756,7 @@ def main(dry_run, verbose, domain, catch_up):
                 total_records += len(d.porkbun_only)
                 total_conflicts += len(d.value_conflicts) + len(d.ttl_conflicts)
             except Exception as e:
+                sync_ok = False
                 logger.error(f"Error processing domain {domain_name}: {e}")
                 if verbose:
                     import traceback
@@ -745,16 +784,13 @@ def main(dry_run, verbose, domain, catch_up):
             print(f"\nDRY RUN: would create catchup branch and commit {total_records} records + {total_conflicts} conflicts")
     else:
         # --- normal sync mode ---
-        for domain_name in domains_to_process:
-            try:
-                process_domain(domain_name, dry_run=dry_run)
-            except Exception as e:
-                logger.error(f"Error processing domain {domain_name}: {e}")
-                if verbose:
-                    import traceback
-                    traceback.print_exc()
+        sync_ok = sync_domains(domains_to_process, dry_run=dry_run, verbose=verbose)
+        if not dry_run:
+            report_service_check(0 if sync_ok else 2)
 
     logger.info("Processing complete")
+    if not sync_ok:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/systemd/dns-sync.container
+++ b/systemd/dns-sync.container
@@ -1,0 +1,20 @@
+[Unit]
+Description=Porkbun DNS sync
+After=network-online.target
+Wants=network-online.target
+
+[Container]
+Image=localhost/dns-sync:latest
+Volume=/data/infrastructure/dns_management:/app:z
+EnvironmentFile=/data/infrastructure/dns_management/etc/porkbun_secrets.env
+Environment=DD_AGENT_HOST=host.containers.internal
+Exec=python scripts/manage_porkbun.py
+
+[Service]
+Type=oneshot
+ExecStartPre=/usr/bin/git -C /data/infrastructure/dns_management pull --ff-only
+ExecStartPre=/usr/bin/git -C /data/infrastructure/dns_management submodule update --init
+TimeoutStartSec=300
+
+[Install]
+WantedBy=default.target

--- a/systemd/dns-sync.timer
+++ b/systemd/dns-sync.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run Porkbun DNS sync daily
+
+[Timer]
+OnCalendar=*-*-* 03:00:00
+Persistent=true
+RandomizedDelaySec=1800
+
+[Install]
+WantedBy=timers.target

--- a/tests/test_main_exit_code.py
+++ b/tests/test_main_exit_code.py
@@ -1,0 +1,89 @@
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+
+from scripts import manage_porkbun
+
+
+@pytest.fixture
+def stub_main_dependencies(monkeypatch):
+    """Stub out everything main() touches before it reaches the sync-failure
+    code path under test, so no real I/O or network calls happen."""
+    monkeypatch.setattr(manage_porkbun, "setup_logging", lambda verbose=False: None)
+    monkeypatch.setattr(manage_porkbun, "discover_base_dir", lambda: None)
+    monkeypatch.setattr(
+        manage_porkbun,
+        "init_config",
+        lambda: {
+            "domains": ["example.com"],
+            manage_porkbun.PORKBUN_PUBLIC_API_KEY: "pub",
+            manage_porkbun.PORKBUN_PRIVATE_API_KEY: "priv",
+            "porkbun_rest_endpoint": "https://example.invalid",
+        },
+    )
+    monkeypatch.setattr(
+        manage_porkbun, "check_credentials", lambda: {"status": "SUCCESS", "yourIp": "1.2.3.4"}
+    )
+    monkeypatch.setattr(manage_porkbun, "process_templates", lambda app_config: None)
+    monkeypatch.setattr(manage_porkbun, "copy_files", lambda: None)
+    # logger is set by setup_logging normally; main() uses the module-level
+    # logger directly via calls like logger.info, so make sure it's usable.
+    monkeypatch.setattr(manage_porkbun, "logger", manage_porkbun.logging.getLogger("test"))
+
+
+def test_main_reports_critical_and_exits_1_on_sync_failure(monkeypatch, stub_main_dependencies):
+    calls = []
+    monkeypatch.setattr(manage_porkbun, "sync_domains", lambda *a, **k: False)
+    monkeypatch.setattr(manage_porkbun, "report_service_check", lambda status: calls.append(status))
+
+    with pytest.raises(SystemExit) as exc_info:
+        manage_porkbun.main.callback(dry_run=False, verbose=False, domain=None, catch_up=False)
+
+    assert calls == [2]
+    assert exc_info.value.code == 1
+
+
+def test_main_reports_ok_and_does_not_exit_on_sync_success(monkeypatch, stub_main_dependencies):
+    calls = []
+    monkeypatch.setattr(manage_porkbun, "sync_domains", lambda *a, **k: True)
+    monkeypatch.setattr(manage_porkbun, "report_service_check", lambda status: calls.append(status))
+
+    # Should not raise SystemExit
+    manage_porkbun.main.callback(dry_run=False, verbose=False, domain=None, catch_up=False)
+
+    assert calls == [0]
+
+
+def test_main_catch_up_mode_exits_nonzero_on_domain_failure(monkeypatch, stub_main_dependencies):
+    """A domain raising during catch-up mode's diff loop must still cause a
+    nonzero exit, mirroring normal-sync mode's sync_ok handling -- otherwise
+    a catch-up run can silently miss a domain's data and still exit 0."""
+
+    def raising_load_domain(domain_name):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(manage_porkbun, "load_domain", raising_load_domain)
+
+    with pytest.raises(SystemExit) as exc_info:
+        manage_porkbun.main.callback(dry_run=False, verbose=False, domain=None, catch_up=True)
+
+    assert exc_info.value.code == 1
+
+
+@pytest.mark.parametrize("sync_result", [True, False])
+def test_main_dry_run_never_reports_service_check(monkeypatch, stub_main_dependencies, sync_result):
+    calls = []
+    monkeypatch.setattr(manage_porkbun, "sync_domains", lambda *a, **k: sync_result)
+    monkeypatch.setattr(manage_porkbun, "report_service_check", lambda status: calls.append(status))
+
+    # main() still honors sync_ok for its own exit code regardless of
+    # dry_run; what we're asserting here is that report_service_check
+    # itself is never invoked while dry_run=True.
+    if sync_result:
+        manage_porkbun.main.callback(dry_run=True, verbose=False, domain=None, catch_up=False)
+    else:
+        with pytest.raises(SystemExit):
+            manage_porkbun.main.callback(dry_run=True, verbose=False, domain=None, catch_up=False)
+
+    assert calls == []

--- a/tests/test_service_check.py
+++ b/tests/test_service_check.py
@@ -1,0 +1,75 @@
+import socket
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from scripts.manage_porkbun import report_service_check
+
+
+class FakeSocket:
+    sent = []
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def sendto(self, data, addr):
+        FakeSocket.sent.append((data, addr))
+
+
+def test_report_service_check_ok_sends_status_zero(monkeypatch):
+    FakeSocket.sent = []
+    monkeypatch.setattr(socket, "socket", lambda *a, **k: FakeSocket())
+    report_service_check(0)
+    assert len(FakeSocket.sent) == 1
+    data, addr = FakeSocket.sent[0]
+    assert data == b"_sc|dns.sync.status|0|h:BatchNode"
+    assert addr == ("172.17.0.1", 8125)
+
+
+def test_report_service_check_critical_sends_status_two(monkeypatch):
+    FakeSocket.sent = []
+    monkeypatch.setattr(socket, "socket", lambda *a, **k: FakeSocket())
+    report_service_check(2)
+    data, _ = FakeSocket.sent[0]
+    assert data == b"_sc|dns.sync.status|2|h:BatchNode"
+
+
+def test_report_service_check_respects_env_overrides(monkeypatch):
+    FakeSocket.sent = []
+    monkeypatch.setenv("DD_AGENT_HOST", "10.88.0.1")
+    monkeypatch.setenv("DD_AGENT_PORT", "9125")
+    monkeypatch.setattr(socket, "socket", lambda *a, **k: FakeSocket())
+    report_service_check(0)
+    _, addr = FakeSocket.sent[0]
+    assert addr == ("10.88.0.1", 9125)
+
+
+def test_report_service_check_never_raises_on_oserror(monkeypatch):
+    class RaisingSocket(FakeSocket):
+        def sendto(self, data, addr):
+            raise OSError("network unreachable")
+
+    monkeypatch.setattr(socket, "socket", lambda *a, **k: RaisingSocket())
+    report_service_check(0)  # must not raise
+
+
+def test_report_service_check_respects_dd_hostname_override(monkeypatch):
+    FakeSocket.sent = []
+    monkeypatch.setenv("DD_HOSTNAME", "lunarBeacon")
+    monkeypatch.setattr(socket, "socket", lambda *a, **k: FakeSocket())
+    report_service_check(0)
+    data, _ = FakeSocket.sent[0]
+    assert data == b"_sc|dns.sync.status|0|h:lunarBeacon"
+
+
+def test_report_service_check_never_raises_on_invalid_port(monkeypatch):
+    FakeSocket.sent = []
+    monkeypatch.setenv("DD_AGENT_PORT", "not-a-port")
+    monkeypatch.setattr(socket, "socket", lambda *a, **k: FakeSocket())
+    report_service_check(0)  # must not raise -- the sync must continue
+    assert FakeSocket.sent == []

--- a/tests/test_sync_domains.py
+++ b/tests/test_sync_domains.py
@@ -1,0 +1,39 @@
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import scripts.manage_porkbun as mp
+
+
+def test_sync_domains_returns_true_when_all_succeed(monkeypatch):
+    calls = []
+
+    def fake_process_domain(domain, dry_run=False):
+        calls.append(domain)
+
+    monkeypatch.setattr(mp, "process_domain", fake_process_domain)
+    result = mp.sync_domains(["a.com", "b.com"], dry_run=True, verbose=False)
+    assert result is True
+    assert calls == ["a.com", "b.com"]
+
+
+def test_sync_domains_returns_false_when_one_domain_errors(monkeypatch):
+    def fake_process_domain(domain, dry_run=False):
+        if domain == "bad.com":
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(mp, "process_domain", fake_process_domain)
+    result = mp.sync_domains(["good.com", "bad.com"], dry_run=True, verbose=False)
+    assert result is False
+
+
+def test_sync_domains_continues_after_one_domain_errors(monkeypatch):
+    calls = []
+
+    def fake_process_domain(domain, dry_run=False):
+        calls.append(domain)
+        if domain == "bad.com":
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(mp, "process_domain", fake_process_domain)
+    mp.sync_domains(["bad.com", "good.com"], dry_run=True, verbose=False)
+    assert calls == ["bad.com", "good.com"]


### PR DESCRIPTION
## Summary
- Containerizes `manage_porkbun.py` to run daily via Podman Quadlet + systemd timer on lunarBeacon (rootless Podman)
- Fixes a real bug: the script always exited 0 even when a domain sync failed, hiding partial failures from monitoring
- Adds a zero-dependency DogStatsD UDP service-check report (`dns.sync.status`) with a reference Datadog monitor config for PagerDuty/Slack alerting
- Adds branch protection on `main` (PR required, no direct pushes, no approval needed) -- this is what makes unattended live-apply safe: the job always applies live, but only ever acts on what's merged
- Design: `docs/superpowers/specs/2026-07-20-lunarbeacon-container-schedule-design.md`
- Plan: `docs/superpowers/plans/2026-07-20-lunarbeacon-container-schedule.md`

## Known gaps (documented in CLAUDE.md / spec)
- `etc` (the DNS config submodule repo) could **not** be branch-protected -- it's private and GitHub's branch protection API requires a paid plan for private repos. A direct push to `etc`'s `main` would still be picked up live on the next scheduled run.
- Companion fix in the `etc` submodule (`NickJLange/external_dns_management_config#4`, still open) adds `etc/.gitignore` for the new `porkbun_secrets.env` credential file -- the parent repo's `.gitignore` can't reach inside a submodule's own working tree.
- Deployment to lunarBeacon itself (git clone, `gh auth login`, `make deploy`, staged rollout) is a manual runbook in CLAUDE.md -- not executed by this PR, since it requires real SSH access to lunarBeacon.

## Test plan
- [x] 34/34 tests passing (`​.venv/bin/python -m pytest tests/ -q`)
- [x] `podman build` verified locally against the Containerfile
- [x] Every task individually reviewed (spec + quality) plus a final whole-branch review; two Important findings from that review (DogStatsD unreachable on rootless Podman's default bridge, missing integration test for the exit-code fix) were fixed and re-reviewed clean
- [ ] Manual: staged rollout on lunarBeacon per CLAUDE.md's "Scheduled sync on lunarBeacon" section (dry-run first, supervised first live run, then enable the timer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs the Porkbun DNS sync in a rootless `Podman` container on a batch host and schedules it daily via `systemd` (03:00 with randomized delay). Adds Datadog service-check reporting, safe submodule pinning to parent `main`, and a configurable host identity (default "BatchNode").

- **New Features**
  - Added `Containerfile`, Quadlet unit `systemd/dns-sync.container`, and daily `systemd/dns-sync.timer` (03:00; `RandomizedDelaySec=1800`); `Makefile` `build`/`deploy` to `BATCH_HOST` (from optional `.env`), enables timer and linger.
  - Rootless `Podman` with `Environment=DD_AGENT_HOST=host.containers.internal`; sends DogStatsD service check `dns.sync.status` and includes `monitoring/datadog-monitor.yaml` (override host with `DD_HOSTNAME`).
  - Pre-run `git pull --ff-only`; `etc` is pinned via `git submodule update --init` (no `--remote`) to a commit merged on this repo’s protected `main`; ignore `etc/porkbun_secrets.env` and `.env`; bumped `etc` pointer to include its secrets ignore.

- **Bug Fixes**
  - Exit non-zero when any domain sync fails in normal and `--catch-up` modes; continue processing and aggregate status; only report service checks when not `--dry-run`.
  - Hardened DogStatsD reporting: correct `h:<hostname>` tag, rootless host routing, and safe port parsing; tests added for service checks and exit paths.

<sup>Written for commit 7bfba327b4cb82fdc566bc380e962a2735dd63f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/NickJLange/external_dns_management/pull/5?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added containerized build and deployment automation for DNS synchronization.
  - Added daily, persistent background synchronization with automatic network and repository updates.
  - Added monitoring alerts for failed, missed, and recovered DNS sync operations.
  - Added status reporting and nonzero failure signaling for unsuccessful synchronizations.

- **Bug Fixes**
  - Improved resilience by continuing synchronization after individual domain errors.
  - Invalid monitoring configuration no longer interrupts synchronization.

- **Security**
  - Prevented local secrets configuration from being tracked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->