### PR TITLE
fix: don't treat Porkbun's non-null prio as drift on non-MX/SRV records

### DIFF
--- a/scripts/manage_porkbun.py
+++ b/scripts/manage_porkbun.py
@@ -306,11 +306,18 @@ def discover_base_dir():
 
 def gen_key(ds: dict[str, str]) -> str:
     """Generate a unique key for a DNS record"""
-    prio = str(ds.get("prio") or "0")
-    if prio in ("None", ""):
+    record_type = ds["type"].lower()
+    if record_type in ("mx", "srv"):
+        prio = str(ds.get("prio") or "0")
+        if prio in ("None", ""):
+            prio = "0"
+    else:
+        # Priority is meaningless for other record types, but Porkbun's API
+        # still returns a non-null value for them (e.g. prio="1" on a TXT
+        # record) -- ignore it here so that doesn't look like drift.
         prio = "0"
     key = "_".join(
-        [ds["name"].lower(), ds["content"], ds["type"].lower(), str(ds["ttl"]).lower(), prio]
+        [ds["name"].lower(), ds["content"], record_type, str(ds["ttl"]).lower(), prio]
     )
     return key
 

--- a/tests/test_diff_domain.py
+++ b/tests/test_diff_domain.py
@@ -111,3 +111,15 @@ def test_mx_priority_drift_detected_as_value_conflict():
     result = diff_domain("example.com", keyed(cfg_rec), keyed(pb_rec))
     assert result.in_sync == 0
     assert len(result.value_conflicts) == 1
+
+
+def test_txt_record_with_nonzero_porkbun_prio_is_in_sync():
+    """Porkbun returns a non-null prio for record types where priority is
+    meaningless (e.g. TXT); gen_key must not treat that as drift."""
+    cfg_txt = make_record("example.com", "TXT", "v=spf1 include:_spf.porkbun.com ~all", ttl="300", prio="None")
+    pb_txt = make_record("example.com", "TXT", "v=spf1 include:_spf.porkbun.com ~all", ttl="300", prio="1")
+    result = diff_domain("example.com", keyed(cfg_txt), keyed(pb_txt))
+    assert result.in_sync == 1
+    assert result.porkbun_only == []
+    assert result.config_only == []
+    assert result.value_conflicts == []


### PR DESCRIPTION
## Summary
- `gen_key()` was including `prio` in the record key for every record type. Porkbun's API returns a non-null `prio` (e.g. `"1"`) for types where priority is meaningless (TXT, A, CNAME, etc.), while local config always has `prio="None"` for those — the mismatch made every scheduled sync detect false drift and delete+recreate the records.
- Fixed by only folding `prio` into the key for `mx`/`srv`, normalizing it to `"0"` for all other types.
- Bumps the `etc` submodule to pick up [external_dns_management_config#5](https://github.com/NickJLange/external_dns_management_config/pull/5), a related but separate fix for `nicklange.family`'s real MX/SRV priority values (that domain had genuinely wrong prio values in its template, not a script bug).
- Confirmed against live lunarBeacon dry-run: 3 of 4 domains went from non-zero add/delete churn to 0/0 before the submodule fix landed; this PR is expected to bring the 4th (`nicklange.family`) to 0/0 as well once deployed.

## Test plan
- [x] New regression test `test_txt_record_with_nonzero_porkbun_prio_is_in_sync` (RED confirmed before fix, GREEN after)
- [x] Full suite: 38/38 passing
- [ ] After merge: `git pull` on lunarBeacon, re-run `--dry-run` for all domains, confirm 0 add/0 delete everywhere

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop treating Porkbun’s non-null prio as drift on non-MX/SRV records. This prevents unnecessary delete/recreate churn during syncs.

- Bug Fixes
  - Include `prio` in keys only for `mx`/`srv`; normalize others to "0".
  - Added regression test for TXT with non-zero Porkbun `prio`.

- Dependencies
  - Bump `etc` submodule to pick up `nicklange.family` MX/SRV priority fix from `external_dns_management_config`.

<sup>Written for commit 0a4d3335902ca02ef2d3038b9f5442e3ac8f8ab8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/NickJLange/external_dns_management/pull/6?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved DNS record synchronization by ignoring irrelevant priority values for non-mail and service records.
  - Prevented TXT records from being incorrectly flagged as out of sync when external systems provide a nonzero priority value.

- **Tests**
  - Added coverage to verify TXT records remain synchronized despite irrelevant priority data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->