### PR TITLE
docs: restore Datadog monitor reference config for dns-sync

### DIFF
--- a/monitoring/datadog-monitor.yaml
+++ b/monitoring/datadog-monitor.yaml
@@ -1,0 +1,87 @@
+# Datadog Monitor Configuration for DNS Sync
+# Deploy via Datadog API: https://docs.datadoghq.com/api/latest/monitors/#create-a-monitor
+#
+# Prerequisites:
+# - Datadog Agent running on lunarBeacon with systemd check enabled
+# - dns-sync.service managed by systemd (via Podman Quadlet)
+
+# Systemd Check Configuration (install on Datadog Agent on lunarBeacon)
+# Place in /etc/datadog-agent/conf.d/systemd.d/conf.yaml
+systemd_check:
+  instances:
+    - unit_names:
+        - cert-renewal.service
+        - dns-sync.service
+
+---
+# Monitor: service entered failed state
+# Fires if the last dns-sync run exited non-zero (Porkbun API error, git pull
+# failure, submodule auth failure, etc.)
+monitor:
+  name: "lunarBeacon - dns-sync.service Failed"
+  type: service check
+  query: '"systemd.service.failed".over("unit:dns-sync.service","host:lunarBeacon").by("host").last(1).count_by_status()'
+  message: |
+    {{#is_alert}}
+    dns-sync.service has entered the failed state on {{host.name}}.
+
+    The daily Porkbun DNS sync did not complete successfully.
+
+    Troubleshoot:
+      ssh lunarBeacon
+      journalctl --user -u dns-sync.service -n 100
+
+    @slack-homelab-alerts
+    {{/is_alert}}
+
+    {{#is_recovery}}
+    dns-sync.service has recovered on {{host.name}}.
+    {{/is_recovery}}
+  options:
+    thresholds:
+      critical: 1
+      ok: 1
+    notify_no_data: false
+    notify_audit: false
+    renotify_interval: 1440
+  tags:
+    - service:dns-sync
+    - env:production
+    - host:lunarBeacon
+  priority: 2
+
+---
+# Monitor: timer has not fired in >26 hours (catches missed runs / timer death)
+monitor_timer:
+  name: "lunarBeacon - dns-sync.timer Stale"
+  type: metric alert
+  query: "max(last_26h):max:systemd.timer.last_trigger_usec{unit:dns-sync.timer,host:lunarBeacon} < 1"
+  message: |
+    {{#is_alert}}
+    dns-sync.timer has not fired on {{host.name}} in over 26 hours.
+
+    The timer may be disabled or the unit may have failed to load.
+
+    Check:
+      ssh lunarBeacon
+      systemctl --user list-timers dns-sync
+      systemctl --user status dns-sync.timer
+
+    @slack-homelab-alerts
+    {{/is_alert}}
+
+    {{#is_recovery}}
+    dns-sync.timer is firing again on {{host.name}}.
+    {{/is_recovery}}
+  options:
+    thresholds:
+      critical: 1
+    notify_no_data: true
+    no_data_timeframe: 1440
+    notify_audit: false
+    renotify_interval: 1440
+  tags:
+    - service:dns-sync
+    - env:production
+    - host:lunarBeacon
+  priority: 2


### PR DESCRIPTION
## Summary
- Restores `monitoring/datadog-monitor.yaml`, deleted in #7, but rebuilt to match `internal_cert_management`'s pattern rather than the old DogStatsD-based one.
- The sibling project keeps this same kind of file as a reference/documentation artifact (not automated via API or GUI -- confirmed no script in that repo ever calls the Datadog Monitors API either), so removing ours outright was inconsistent with that pattern.
- lunarBeacon's Datadog agent systemd check config (`/etc/datadog-agent/conf.d/systemd.d/conf.yaml`) already lists `dns-sync.service` alongside `cert-renewal.service` -- this file documents the two alert rules (service-failed, timer-stale) that should be applied via the Monitors API to match cert-renewal's existing monitors, once someone does that setup step.

## Test plan
- N/A -- reference/documentation file only, no code changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the Datadog monitor reference for dns-sync by adding monitoring/datadog-monitor.yaml. Documents two monitors (service failed, timer stale) to match the internal_cert_management pattern; docs-only, no code changes.

- **Migration**
  - Create the two monitors via the Datadog Monitors API using the provided queries and messages.
  - Ensure the Datadog Agent on lunarBeacon has the systemd check enabled and includes `dns-sync.service` in `/etc/datadog-agent/conf.d/systemd.d/conf.yaml`.

<sup>Written for commit 9e926b7dc499fe94365ba9136fe59ea5ecf4b16b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/NickJLange/external_dns_management/pull/8?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

