### PR TITLE
fix: install .timer units to systemd user dir, not Quadlet dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,6 @@ deploy:
 	@echo "Deploying dns-sync to $(BATCH_HOST):$(DEPLOY_PATH)..."
 	ssh $(BATCH_HOST) 'test -d $(DEPLOY_PATH) || git clone --recurse-submodules git@github.com:NickJLange/external_dns_management.git $(DEPLOY_PATH)'
 	ssh $(BATCH_HOST) 'cd $(DEPLOY_PATH) && podman build -t localhost/dns-sync:latest -f Containerfile .'
-	ssh $(BATCH_HOST) 'mkdir -p ~/.config/containers/systemd && cp $(DEPLOY_PATH)/systemd/dns-sync.container $(DEPLOY_PATH)/systemd/dns-sync.timer ~/.config/containers/systemd/'
+	ssh $(BATCH_HOST) 'mkdir -p ~/.config/containers/systemd ~/.config/systemd/user && cp $(DEPLOY_PATH)/systemd/dns-sync.container ~/.config/containers/systemd/ && cp $(DEPLOY_PATH)/systemd/dns-sync.timer ~/.config/systemd/user/'
 	ssh $(BATCH_HOST) 'systemctl --user daemon-reload && systemctl --user enable --now dns-sync.timer && loginctl enable-linger $$(whoami)'
 	@echo "Deploy complete. etc/porkbun_secrets.env and gh auth login are one-time manual steps."


### PR DESCRIPTION
## Summary
- \`make deploy\` copied both \`dns-sync.container\` and \`dns-sync.timer\` into \`~/.config/containers/systemd/\`, but Quadlet only generates units from recognized extensions (\`.container\`, \`.volume\`, \`.kube\`, \`.network\`, \`.image\`, \`.pod\`, \`.build\`) -- a plain \`.timer\` file there is never picked up, so \`systemctl --user enable --now dns-sync.timer\` failed with \`Unit dns-sync.timer does not exist\`.
- Discovered while actually installing the timer on lunarBeacon. Confirmed the correct location by checking the sibling \`cert-renewal\` deployment: its \`.timer\` is enabled from \`~/.config/systemd/user/timers.target.wants/\`, not the Quadlet directory.
- Fix: \`.container\` still goes to \`~/.config/containers/systemd/\`, \`.timer\` now goes to \`~/.config/systemd/user/\`.

## Test plan
- [x] Manually installed with the corrected paths on lunarBeacon -- \`systemctl --user enable --now dns-sync.timer\` succeeded, \`systemctl --user list-timers dns-sync\` shows it scheduled correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install `dns-sync.timer` to the user systemd dir (`~/.config/systemd/user/`) instead of the Quadlet dir so `systemctl --user` can find and enable it. `make deploy` now creates the user unit dir, copies the timer there, keeps `dns-sync.container` in `~/.config/containers/systemd/`, and successfully runs `systemctl --user enable --now dns-sync.timer`.

<sup>Written for commit 8fef3fadb9b905c0878a32d2eea2c9d05bb2e753. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/NickJLange/external_dns_management/pull/9?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

