### PR TITLE
chore: scrub PII from public repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,12 +22,12 @@ Note: avoid `--verbose` in dry-run — debug output includes plaintext API crede
 **Dry-run (safe, no DNS changes):**
 ```bash
 .venv/bin/python scripts/manage_porkbun.py --dry-run
-.venv/bin/python scripts/manage_porkbun.py --dry-run --domain nicklange.family
+.venv/bin/python scripts/manage_porkbun.py --dry-run --domain example.com
 ```
 
 **Live sync — only after reviewing dry-run output:**
 ```bash
-.venv/bin/python scripts/manage_porkbun.py --domain nicklange.family
+.venv/bin/python scripts/manage_porkbun.py --domain example.com
 ```
 
 ## Config

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ porkbun_secret_api_key=(OR USE ENV VAR PORKBUN_SECRET_API_KEY)
 porkbun_rest_endpoint=https://api-ipv4.porkbun.com/api/json/v3
 
 [domains]
-5l-labs.com
+example.com
 myhouse.com
 etc 
 etc
@@ -26,10 +26,10 @@ etc
 ### DNS domain format
 
 ```
-[5l-labs.com]
+[example.com]
 #FORMAT: TYPE KEY VALUE TTL [PRIO]
 # Lazy use of four spaces to support TXT records below - maybe increase to 20 down the line
-ALIAS    5l-labs.com    pixie.porkbun.com    300
+ALIAS    example.com    pixie.porkbun.com    300
 
 ```
 

--- a/scripts/lego.sh
+++ b/scripts/lego.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
+set -a
+. ../etc/lego.env
+set +a
+
 echo "Renewing Certs"
-podman run -v ../lego-data/:/.lego/ --env-file ../etc/lego.env -it goacme/lego --email dns@wafuu.design --dns porkbun --domains '*.newyork.nicklange.family' --domains newyork.nicklange.family run
-podman run -v ../lego-data/:/.lego/ --env-file ../etc/lego.env -it goacme/lego --email dns@wafuu.design --dns porkbun --domains '*.wisconsin.nicklange.family' --domains wisconsin.nicklange.family run
-podman run -v ../lego-data/:/.lego/ --env-file ../etc/lego.env -it goacme/lego --email dns@wafuu.design --dns porkbun --domains '*.miyagi.nicklange.family' --domains miyagi.nicklange.family run
+for host in $LEGO_HOSTS; do
+  podman run -v ../lego-data/:/.lego/ --env-file ../etc/lego.env -it goacme/lego \
+    --email "$LEGO_EMAIL" --dns porkbun \
+    --domains "*.$host.$LEGO_BASE_DOMAIN" --domains "$host.$LEGO_BASE_DOMAIN" run
+done

--- a/scripts/lego.sh
+++ b/scripts/lego.sh
@@ -1,11 +1,22 @@
 #!/bin/sh
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
 set -a
-. ../etc/lego.env
+. "$REPO_ROOT/etc/lego.env"
 set +a
 
+: "${LEGO_EMAIL:?LEGO_EMAIL not set in etc/lego.env}"
+: "${LEGO_BASE_DOMAIN:?LEGO_BASE_DOMAIN not set in etc/lego.env}"
+: "${LEGO_HOSTS:?LEGO_HOSTS not set in etc/lego.env}"
+
 echo "Renewing Certs"
+status=0
 for host in $LEGO_HOSTS; do
-  podman run -v ../lego-data/:/.lego/ --env-file ../etc/lego.env -it goacme/lego \
+  podman run -v "$REPO_ROOT/lego-data/:/.lego/" --env-file "$REPO_ROOT/etc/lego.env" goacme/lego \
     --email "$LEGO_EMAIL" --dns porkbun \
-    --domains "*.$host.$LEGO_BASE_DOMAIN" --domains "$host.$LEGO_BASE_DOMAIN" run
+    --domains "*.$host.$LEGO_BASE_DOMAIN" --domains "$host.$LEGO_BASE_DOMAIN" run || status=1
 done
+exit "$status"


### PR DESCRIPTION
## Summary
- `scripts/lego.sh` no longer hardcodes the real ACME registration email or the three internal location-coded subdomains — these now come from `LEGO_EMAIL`/`LEGO_BASE_DOMAIN`/`LEGO_HOSTS` in `etc/lego.env` (see companion PR NickJLange/external_dns_management_config#6).
- `README.md` / `CLAUDE.md` domain examples replaced with a generic `example.com` placeholder.

Follow-up from PII feedback on PR #10.

## Test plan
- [ ] Merge companion `etc` submodule PR first (adds the new env vars) so `lego.sh` has real values to source when actually run.
- [ ] `sh scripts/lego.sh` (with the etc submodule updated) still issues certs for the same three hosts as before.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scrubbed hardcoded emails and internal domains; docs now use `example.com` and the `etc` submodule is bumped. `scripts/lego.sh` now sources `LEGO_EMAIL`/`LEGO_BASE_DOMAIN`/`LEGO_HOSTS` from `etc/lego.env`, resolves paths from its own directory, runs non-interactively, validates required vars, and exits nonzero if any renewal fails.

- **Migration**
  - Update the `etc` submodule and set `LEGO_EMAIL`, `LEGO_BASE_DOMAIN`, and `LEGO_HOSTS` in `etc/lego.env`.
  - Run `sh scripts/lego.sh` to issue certs for the configured hosts via `goacme/lego`.

<sup>Written for commit 936fc2d75aaa817cd75516fb42347f6e1bf2b7dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/NickJLange/external_dns_management/pull/11?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a dry-run command example using `example.com`.
  * Updated DNS configuration examples to use `example.com`.

* **Enhancements**
  * Streamlined TLS certificate renewal for multiple hosts using configurable environment settings.
  * Certificate renewal now supports dynamic host and email configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->